### PR TITLE
crypto: use pre-allocated shash transform to generate token and ticket_key

### DIFF
--- a/net/quic/crypto.h
+++ b/net/quic/crypto.h
@@ -76,5 +76,8 @@ int quic_crypto_key_update(struct quic_crypto *crypto, u8 *key, unsigned int len
 void quic_crypto_set_key_update_ts(struct quic_crypto *crypto, u32 key_update_ts);
 int quic_crypto_get_retry_tag(struct sk_buff *skb, struct quic_connection_id *odcid,
 			      u32 version, u8 *tag);
-int quic_crypto_generate_token(void *data, char *label, u8 *token, u32 len);
-int quic_crypto_generate_session_ticket_key(void *data, u8 *key, u32 len);
+int quic_crypto_listen_init(struct quic_crypto *crypto);
+int quic_crypto_generate_token(struct quic_crypto *crypto, void *data, char *label,
+			       u8 *token, u32 len);
+int quic_crypto_generate_session_ticket_key(struct quic_crypto *crypto, void *data,
+					    u8 *key, u32 len);

--- a/net/quic/crypto.h
+++ b/net/quic/crypto.h
@@ -74,8 +74,8 @@ int quic_crypto_get_secret(struct quic_crypto *crypto, struct quic_crypto_secret
 void quic_crypto_destroy(struct quic_crypto *crypto);
 int quic_crypto_key_update(struct quic_crypto *crypto, u8 *key, unsigned int len);
 void quic_crypto_set_key_update_ts(struct quic_crypto *crypto, u32 key_update_ts);
-int quic_crypto_get_retry_tag(struct sk_buff *skb, struct quic_connection_id *odcid,
-			      u32 version, u8 *tag);
+int quic_crypto_get_retry_tag(struct quic_crypto *crypto, struct sk_buff *skb,
+			      struct quic_connection_id *odcid, u32 version, u8 *tag);
 int quic_crypto_listen_init(struct quic_crypto *crypto);
 int quic_crypto_generate_token(struct quic_crypto *crypto, void *data, char *label,
 			       u8 *token, u32 len);

--- a/net/quic/frame.c
+++ b/net/quic/frame.c
@@ -112,7 +112,8 @@ static struct sk_buff *quic_frame_new_token_create(struct sock *sk, void *data, 
 
 	p = buf;
 	p = quic_put_int(p, 0, 1); /* regular token */
-	if (quic_crypto_generate_token((u8 *)da, "path_verification", p, 16))
+	if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				       (u8 *)da, "path_verification", p, 16))
 		return NULL;
 
 	skb = alloc_skb(len + 4, GFP_ATOMIC);
@@ -285,7 +286,8 @@ static struct sk_buff *quic_frame_new_connection_id_create(struct sock *sk, void
 	p = quic_put_var(p, 16);
 	quic_generate_id(&scid, 16);
 	p = quic_put_data(p, scid.data, scid.len);
-	if (quic_crypto_generate_token(scid.data, "stateless_reset", token, 16))
+	if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				       scid.data, "stateless_reset", token, 16))
 		return NULL;
 	p = quic_put_data(p, token, 16);
 	frame_len = (u32)(p - frame);
@@ -1482,7 +1484,8 @@ int quic_frame_get_transport_params_ext(struct sock *sk, struct quic_transport_p
 		if (params->stateless_reset) {
 			p = quic_put_var(p, QUIC_TRANSPORT_PARAM_STATELESS_RESET_TOKEN);
 			p = quic_put_var(p, 16);
-			if (quic_crypto_generate_token(scid->data, "stateless_reset", token, 16))
+			if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+						       scid->data, "stateless_reset", token, 16))
 				return -1;
 			p = quic_put_data(p, token, 16);
 		}

--- a/net/quic/input.c
+++ b/net/quic/input.c
@@ -133,7 +133,8 @@ static int quic_do_listen_rcv(struct sock *sk, struct sk_buff *skb)
 			return quic_packet_retry_transmit(sk, &req);
 		}
 		p = token.data;
-		if (quic_crypto_generate_token(&req.da, "path_verification", data, 16) ||
+		if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+					       &req.da, "path_verification", data, 16) ||
 		    memcmp(p + 1, data, 16))
 			goto err;
 		req.retry = *p;

--- a/net/quic/packet.c
+++ b/net/quic/packet.c
@@ -81,7 +81,9 @@ static int quic_packet_handshake_retry_process(struct sock *sk, struct sk_buff *
 	if (len < 16)
 		goto err;
 	version = quic_local(sk)->version;
-	if (quic_crypto_get_retry_tag(skb, &scid, version, tag) || memcmp(tag, p + len - 16, 16))
+	if (quic_crypto_get_retry_tag(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				      skb, &scid, version, tag) ||
+	    memcmp(tag, p + len - 16, 16))
 		goto err;
 	if (quic_data_dup(quic_token(sk), p, len - 16))
 		goto err;
@@ -716,7 +718,8 @@ static struct sk_buff *quic_packet_retry_create(struct sock *sk, struct quic_req
 	p = quic_put_int(p, req->dcid.len, 1);
 	p = quic_put_data(p, req->dcid.data, req->dcid.len);
 	p = quic_put_data(p, token, tokenlen);
-	if (quic_crypto_get_retry_tag(skb, &req->dcid, req->version, tag)) {
+	if (quic_crypto_get_retry_tag(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				      skb, &req->dcid, req->version, tag)) {
 		kfree_skb(skb);
 		return NULL;
 	}

--- a/net/quic/packet.c
+++ b/net/quic/packet.c
@@ -690,7 +690,8 @@ static struct sk_buff *quic_packet_retry_create(struct sock *sk, struct quic_req
 
 	p = token;
 	p = quic_put_int(p, 1, 1); /* retry token */
-	if (quic_crypto_generate_token(&req->da, "path_verification", p, 16))
+	if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				       &req->da, "path_verification", p, 16))
 		return NULL;
 
 	len = 1 + 4 + 1 + req->scid.len + 1 + req->dcid.len + tokenlen + 16;
@@ -793,7 +794,8 @@ static struct sk_buff *quic_packet_stateless_reset_create(struct sock *sk,
 	u8 *p, token[16];
 	int len, hlen;
 
-	if (quic_crypto_generate_token(req->dcid.data, "stateless_reset", token, 16))
+	if (quic_crypto_generate_token(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+				       req->dcid.data, "stateless_reset", token, 16))
 		return NULL;
 
 	len = 64;

--- a/net/quic/protocol.c
+++ b/net/quic/protocol.c
@@ -262,6 +262,8 @@ static int quic_inet_listen(struct socket *sock, int backlog)
 	if (!hlist_unhashed(&quic_sk(sk)->inet.sk.sk_node))
 		goto out;
 
+	if (quic_crypto_listen_init(quic_crypto(sk, QUIC_CRYPTO_INITIAL)))
+		goto out;
 	inet_sk_set_state(sk, QUIC_SS_LISTENING);
 	err = sk->sk_prot->hash(sk);
 out:

--- a/net/quic/protocol.c
+++ b/net/quic/protocol.c
@@ -262,7 +262,8 @@ static int quic_inet_listen(struct socket *sock, int backlog)
 	if (!hlist_unhashed(&quic_sk(sk)->inet.sk.sk_node))
 		goto out;
 
-	if (quic_crypto_listen_init(quic_crypto(sk, QUIC_CRYPTO_INITIAL)))
+	err = quic_crypto_listen_init(quic_crypto(sk, QUIC_CRYPTO_INITIAL));
+	if (err)
 		goto out;
 	inet_sk_set_state(sk, QUIC_SS_LISTENING);
 	err = sk->sk_prot->hash(sk);

--- a/net/quic/socket.c
+++ b/net/quic/socket.c
@@ -1349,7 +1349,8 @@ static int quic_sock_get_session_ticket(struct sock *sk, int len,
 	if (quic_is_serv(sk)) { /* get ticket_key for server */
 		union quic_addr *da = quic_path_addr(quic_dst(sk));
 
-		if (quic_crypto_generate_session_ticket_key(da, key, 64))
+		if (quic_crypto_generate_session_ticket_key(quic_crypto(sk, QUIC_CRYPTO_INITIAL),
+							    da, key, 64))
 			return -EINVAL;
 		ticket = key;
 		ticket_len = 64;


### PR DESCRIPTION
The crypto_alloc_shash is a sleepable function. On some platforms, processing the received packet is in atomic context that is invalied for sleepable function.

The quic_sock::crypto[QUIC_CRYPTO_INITIAL].secret_tfm is alloced when the socket is connected and destroyed when the socket is destroyed. Instead to alloc new transform, we reuse it to generate token and ticket_key.