### PR TITLE
socket: update cipher_type in quic_sock_set_transport_param

### DIFF
--- a/net/quic/socket.c
+++ b/net/quic/socket.c
@@ -779,6 +779,7 @@ static int quic_sock_set_transport_param(struct sock *sk, struct quic_transport_
 	quic_set_param_if_not_zero(stateless_reset);
 	quic_set_param_if_not_zero(recv_session_ticket);
 	quic_set_param_if_not_zero(cert_request);
+	quic_set_param_if_not_zero(cipher_type);
 	quic_set_param_if_not_zero(version);
 
 	if (p->remote) {


### PR DESCRIPTION
The cipher_type is no update when user to set it. Therefore, user can't to chose cipher suites.