### PR TITLE
socket: fix some build warnings/errors

### DIFF
--- a/net/quic/socket.c
+++ b/net/quic/socket.c
@@ -391,8 +391,6 @@ static int quic_msghdr_parse(struct sock *sk, struct msghdr *msg, struct quic_ha
 
 static int quic_wait_for_send(struct sock *sk, u64 stream_id, long timeo, u32 msg_len)
 {
-	u8 state;
-
 	for (;;) {
 		int err = 0, exit = 1;
 		DEFINE_WAIT(wait);
@@ -413,7 +411,7 @@ static int quic_wait_for_send(struct sock *sk, u64 stream_id, long timeo, u32 ms
 		}
 		if (quic_is_closed(sk)) {
 			err = -EPIPE;
-			pr_warn("wait sndbuf state %u, %d\n", state, err);
+			pr_warn("wait sndbuf closed %d\n", err);
 			goto out;
 		}
 

--- a/net/quic/socket.c
+++ b/net/quic/socket.c
@@ -14,7 +14,6 @@
 #include "frame.h"
 #include <net/inet_common.h>
 #include <linux/version.h>
-#include <asm/ioctls.h>
 
 bool quic_request_sock_exists(struct sock *sk, union quic_addr *sa, union quic_addr *da)
 {
@@ -1639,31 +1638,9 @@ out:
 	inet_sk_set_state(sk, QUIC_SS_CLOSED);
 }
 
-static int quic_ioctl(struct sock *sk, int cmd, int *karg)
-{
-	struct sk_buff *skb;
-	int rc = 0;
-
-	lock_sock(sk);
-	switch (cmd) {
-	case SIOCINQ:
-		*karg = 0;
-		skb = skb_peek(&sk->sk_receive_queue);
-		if (skb)
-			*karg = skb->len;
-		break;
-	default:
-		rc = -ENOIOCTLCMD;
-		break;
-	}
-	release_sock(sk);
-	return rc;
-}
-
 struct proto quic_prot = {
 	.name		=  "QUIC",
 	.owner		=  THIS_MODULE,
-	.ioctl		=  quic_ioctl,
 	.init		=  quic_init_sock,
 	.destroy	=  quic_destroy_sock,
 	.shutdown	=  quic_shutdown,
@@ -1688,7 +1665,6 @@ struct proto quic_prot = {
 struct proto quicv6_prot = {
 	.name		=  "QUICv6",
 	.owner		=  THIS_MODULE,
-	.ioctl		=  quic_ioctl,
 	.init		=  quic_init_sock,
 	.destroy	=  quic_destroy_sock,
 	.shutdown	=  quic_shutdown,


### PR DESCRIPTION
Remove the state in quic_wait_for_send which is uninitinalized when used.

The quic_ioctl is incompatible with the function pointer. And the arg is from userspace, put_user should be used to set value.