### PR TITLE
output: do not retransmit packets if the crypto isn't ready

### DIFF
--- a/net/quic/output.c
+++ b/net/quic/output.c
@@ -395,7 +395,7 @@ next:
 		goto next;
 	}
 
-	quic_packet_config(sk, snd_cb->level);
+	quic_packet_config(sk, (snd_cb->level ?: outq->level));
 	quic_packet_tail(sk, skb);
 	quic_packet_flush(sk);
 

--- a/net/quic/output.h
+++ b/net/quic/output.h
@@ -25,6 +25,11 @@ struct quic_outqueue {
 	u32 max_idle_timeout;
 	u32 max_ack_delay;
 	u8 grease_quic_bit;
+	/* Use for 0-RTT/1-RTT DATA (re)transmit,
+	 * as QUIC_SND_CB(skb)->level is always QUIC_CRYPTO_APP.
+	 * Set this level to QUIC_CRYPTO_EARLY or QUIC_CRYPTO_APP
+	 * when the corresponding crypto is ready for send.
+	 */
 	u8 level;
 
 	u32 close_errcode;


### PR DESCRIPTION
A client receives the ACK for its 0-RTT data after the handshake. When the rtx timer timeout before handshake is completed, it may cause a crash in quic_crypto_encrypt.