### PR TITLE
Implement SIGPIPE/MSG_NOSIGNAL for quick_sendmsg and ignore MSG_BATCH

### DIFF
--- a/libquic/quic.man
+++ b/libquic/quic.man
@@ -145,6 +145,11 @@ and `QUIC_HANDSHAKE_INFO` discribed in
 The `flags` parameter in `sendmsg()` can be set to the following values:
 
 .IP \[bu] 4
+.B `MSG_NOSIGNAL`:
+See
+.BR sendmsg (2).
+
+.IP \[bu] 4
 .B `MSG_MORE`:
 Indicates that the data will be held until the next data is sent without
 this flag.

--- a/modules/net/quic/socket.c
+++ b/modules/net/quic/socket.c
@@ -448,7 +448,7 @@ out:
 	(MSG_STREAM_NEW | MSG_STREAM_FIN | MSG_STREAM_UNI | MSG_STREAM_DONTWAIT)
 
 #define QUIC_MSG_FLAGS \
-	(QUIC_MSG_STREAM_FLAGS | MSG_MORE | MSG_DONTWAIT | MSG_DATAGRAM | MSG_NOSIGNAL)
+	(QUIC_MSG_STREAM_FLAGS | MSG_BATCH | MSG_MORE | MSG_DONTWAIT | MSG_DATAGRAM | MSG_NOSIGNAL)
 
 static int quic_msghdr_parse(struct sock *sk, struct msghdr *msg, struct quic_handshake_info *hinfo,
 			     struct quic_stream_info *sinfo, bool *has_hinfo)

--- a/modules/net/quic/socket.c
+++ b/modules/net/quic/socket.c
@@ -448,7 +448,7 @@ out:
 	(MSG_STREAM_NEW | MSG_STREAM_FIN | MSG_STREAM_UNI | MSG_STREAM_DONTWAIT)
 
 #define QUIC_MSG_FLAGS \
-	(QUIC_MSG_STREAM_FLAGS | MSG_MORE | MSG_DONTWAIT | MSG_DATAGRAM)
+	(QUIC_MSG_STREAM_FLAGS | MSG_MORE | MSG_DONTWAIT | MSG_DATAGRAM | MSG_NOSIGNAL)
 
 static int quic_msghdr_parse(struct sock *sk, struct msghdr *msg, struct quic_handshake_info *hinfo,
 			     struct quic_stream_info *sinfo, bool *has_hinfo)
@@ -825,6 +825,8 @@ static int quic_sendmsg(struct sock *sk, struct msghdr *msg, size_t msg_len)
 out:
 	err = bytes;
 err:
+	if (err < 0 && !has_hinfo && !(flags & MSG_DATAGRAM))
+		err = sk_stream_error(sk, flags, err);
 	release_sock(sk);
 	return err;
 }


### PR DESCRIPTION
It's common to pass MSG_NOSIGNAL to sendmsg() and it should at least be ignore instead
of generating EINVAL.

With this change sendmsg() on a stream generates SIGPIPE together with EPIPE,
this makes it more natural when converting tcp sockets to quic streams.

MSG_BATCH should also be ignored, as it's added internally within
sendmmsg().