### PR TITLE
stream: update send.active_stream_id when peer opens a bidi stream

### DIFF
--- a/modules/net/quic/stream.c
+++ b/modules/net/quic/stream.c
@@ -301,6 +301,8 @@ struct quic_stream *quic_stream_recv_get(struct quic_stream_table *streams, s64 
 	stream = quic_stream_recv_create(streams, stream_id, is_serv);
 	if (!stream)
 		return ERR_PTR(-ENOSTR);
+	if (quic_stream_id_send(stream_id, is_serv))
+		streams->send.active_stream_id = stream_id;
 	return stream;
 }
 


### PR DESCRIPTION
send.active_stream_id serves as the default stream_id when users call sendmsg() without specifying stream_info. It is set to the most recently opened stream.

Since bidirectional (bidi) streams allow data transmission from either endpoint, this patch ensures that send.active_stream_id is also updated when the peer opens a new bidi stream, allowing users to send data on it without explicitly specifying the stream ID.