### PR TITLE
let libquic avoid logging by default

### DIFF
--- a/libquic/handshake.c
+++ b/libquic/handshake.c
@@ -48,7 +48,11 @@ struct quic_ctx {
 	uint8_t is_serv:1;
 };
 
-static int quic_log_level = LOG_NOTICE;
+/*
+ * The caller needs to opt-in in order
+ * to get log messages
+ */
+static int quic_log_level = -1;
 static void (*quic_log_func)(int level, const char *msg);
 
 static void quic_log_error(char const *fmt, ...);

--- a/libquic/handshake.c
+++ b/libquic/handshake.c
@@ -53,7 +53,7 @@ struct quic_ctx {
  * to get log messages
  */
 static int quic_log_level = -1;
-static void (*quic_log_func)(int level, const char *msg);
+static quic_set_log_func_t quic_log_func;
 
 static void quic_log_error(char const *fmt, ...);
 
@@ -158,20 +158,28 @@ static void quic_log_gnutls_error(int error)
  * quic_set_log_level - change the log_level
  * @level: the level it changes to (LOG_XXX from sys/syslog.h)
  *
+ * Return values:
+ * - The old @level
  */
-void quic_set_log_level(int level)
+int quic_set_log_level(int level)
 {
+	int old = quic_log_level;
 	quic_log_level = level;
+	return old;
 }
 
 /**
  * quic_set_log_func - change the log func
  * @func: the log func it changes to
  *
+ * Return values:
+ * - The old @func
  */
-void quic_set_log_func(void (*func)(int level, const char *msg))
+quic_set_log_func_t quic_set_log_func(quic_set_log_func_t func)
 {
+	quic_set_log_func_t old = quic_log_func;
 	quic_log_func = func;
+	return old;
 }
 
 /**

--- a/libquic/handshake.c
+++ b/libquic/handshake.c
@@ -51,22 +51,29 @@ struct quic_ctx {
 static int quic_log_level = LOG_NOTICE;
 static void (*quic_log_func)(int level, const char *msg);
 
+static void quic_log_error(char const *fmt, ...);
+
 /**
  * quic_log_debug - log msg with debug level
  *
  */
-void quic_log_debug(char const *fmt, ...)
+static void quic_log_debug(char const *fmt, ...)
 {
 	char msg[128];
 	va_list arg;
+	int rc;
 
 	if (quic_log_level < LOG_DEBUG)
 		return;
 
 	va_start(arg, fmt);
-	if (vsnprintf(msg, sizeof(msg), fmt, arg) < 0)
-		printf("%s: msg size is greater than 128 bytes!\n", __func__);
+	rc = vsnprintf(msg, sizeof(msg), fmt, arg);
 	va_end(arg);
+	if (rc < 0) {
+		quic_log_error("%s: msg size is greater than 128 bytes!",
+			       __func__);
+		return;
+	}
 
 	if (quic_log_func) {
 		quic_log_func(LOG_DEBUG, msg);
@@ -79,18 +86,23 @@ void quic_log_debug(char const *fmt, ...)
  * quic_log_notice - log msg with notice level
  *
  */
-void quic_log_notice(char const *fmt, ...)
+static void quic_log_notice(char const *fmt, ...)
 {
 	char msg[128];
 	va_list arg;
+	int rc;
 
 	if (quic_log_level < LOG_NOTICE)
 		return;
 
 	va_start(arg, fmt);
-	if (vsnprintf(msg, sizeof(msg), fmt, arg) < 0)
-		printf("%s: msg size is greater than 128 bytes!\n", __func__);
+	rc = vsnprintf(msg, sizeof(msg), fmt, arg);
 	va_end(arg);
+	if (rc < 0) {
+		quic_log_error("%s: msg size is greater than 128 bytes!",
+			       __func__);
+		return;
+	}
 
 	if (quic_log_func) {
 		quic_log_func(LOG_NOTICE, msg);
@@ -103,18 +115,23 @@ void quic_log_notice(char const *fmt, ...)
  * quic_log_error - log msg with error level
  *
  */
-void quic_log_error(char const *fmt, ...)
+static void quic_log_error(char const *fmt, ...)
 {
 	char msg[128];
 	va_list arg;
+	int rc;
 
 	if (quic_log_level < LOG_ERR)
 		return;
 
 	va_start(arg, fmt);
-	if (vsnprintf(msg, sizeof(msg), fmt, arg) < 0)
-		printf("%s: msg size is greater than 128 bytes!\n", __func__);
+	rc = vsnprintf(msg, sizeof(msg), fmt, arg);
 	va_end(arg);
+	if (rc < 0) {
+		snprintf(msg, sizeof(msg),
+			 "%s: msg size is greater than 128 bytes!",
+			 __func__);
+	}
 
 	if (quic_log_func) {
 		quic_log_func(LOG_ERR, msg);
@@ -128,7 +145,7 @@ void quic_log_error(char const *fmt, ...)
  * @error: the error code returned from gnutls APIs
  *
  */
-void quic_log_gnutls_error(int error)
+static void quic_log_gnutls_error(int error)
 {
 	quic_log_error("gnutls: %s (%d)", gnutls_strerror(error), error);
 }

--- a/libquic/netinet/quic.h
+++ b/libquic/netinet/quic.h
@@ -51,5 +51,6 @@ ssize_t quic_sendmsg(int sockfd, const void *msg, size_t len,
 ssize_t quic_recvmsg(int sockfd, void *msg, size_t len,
 		     int64_t *sid, uint32_t *flags);
 
-void quic_set_log_func(void (*func)(int level, const char *msg));
-void quic_set_log_level(int level);
+typedef void (*quic_set_log_func_t)(int level, const char *msg);
+quic_set_log_func_t quic_set_log_func(quic_set_log_func_t func);
+int quic_set_log_level(int level);

--- a/tests/alpn_test.c
+++ b/tests/alpn_test.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/quic.h>
+#include <sys/syslog.h>
 
 static const char *parse_address(
 	char const *address, char const *port, struct sockaddr_storage *sas)
@@ -329,6 +330,8 @@ int main(int argc, char *argv[])
 		printf("%s server|client ...\n", argv[0]);
 		return 0;
 	}
+
+	quic_set_log_level(LOG_NOTICE);
 
 	if (!strcmp(argv[1], "client"))
 		return do_client(argc, argv);

--- a/tests/func_test.c
+++ b/tests/func_test.c
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/quic.h>
+#include <sys/syslog.h>
 
 #define MSG_LEN	4096
 char msg[MSG_LEN + 1];
@@ -2291,6 +2292,8 @@ int main(int argc, char *argv[])
 		printf("%s server|client ...\n", argv[0]);
 		return 0;
 	}
+
+	quic_set_log_level(LOG_NOTICE);
 
 	if (!strcmp(argv[1], "client"))
 		return do_client(argc, argv);

--- a/tests/http3_test.c
+++ b/tests/http3_test.c
@@ -897,6 +897,8 @@ int main(int argc, char *argv[])
 	if (argc < 2)
 		goto err;
 
+	quic_set_log_level(http_log_level);
+
 	if (!strcmp(argv[1], "-c")) {
 		if (argc < 3) {
 			http_log_info("\n  %s -c <URI>\n", argv[0]);

--- a/tests/perf_test.c
+++ b/tests/perf_test.c
@@ -10,6 +10,7 @@
 #include <linux/tls.h>
 #include <arpa/inet.h>
 #include <netinet/quic.h>
+#include <sys/syslog.h>
 
 #define SND_MSG_LEN	4096
 #define RCV_MSG_LEN	4096 * 16
@@ -378,6 +379,8 @@ int main(int argc, char *argv[])
 			printf("parse options error\n");
 		return -1;
 	}
+
+	quic_set_log_level(LOG_NOTICE);
 
 	if (!opts.is_serv)
 		return do_client(&opts);

--- a/tests/sample_test.c
+++ b/tests/sample_test.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/quic.h>
+#include <sys/syslog.h>
 
 static const char *parse_address(
 	char const *address, char const *port, struct sockaddr_storage *sas)
@@ -172,6 +173,8 @@ int main(int argc, char *argv[])
 		printf("%s server|client ...\n", argv[0]);
 		return 0;
 	}
+
+	quic_set_log_level(LOG_NOTICE);
 
 	if (!strcmp(argv[1], "client"))
 		return do_client(argc, argv);

--- a/tests/ticket_test.c
+++ b/tests/ticket_test.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/quic.h>
+#include <sys/syslog.h>
 
 static uint8_t ticket[4096];
 
@@ -416,6 +417,8 @@ int main(int argc, char *argv[])
 		printf("%s server|client ...\n", argv[0]);
 		return 0;
 	}
+
+	quic_set_log_level(LOG_NOTICE);
 
 	if (!strcmp(argv[1], "client"))
 		return do_client(argc, argv);


### PR DESCRIPTION
Doing a printf() from within a library can lead to data corruption!
    
The caller needs to opt-in via quic_set_log_level() and
quic_set_log_func() if desired.