### PR TITLE
Makefile: allow forcing kernel module build or skip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,15 +9,26 @@ PKG_CHECK_MODULES([LIBGNUTLS], [gnutls >= 3.7.0])
 AC_SUBST([LIBGNUTLS_CFLAGS])
 AC_SUBST([LIBGNUTLS_LIBS])
 
-AC_SUBST([kernel], [/lib/modules/`uname -r`])
-AC_CHECK_FILE([$kernel/kernel/net/quic],
-	      [AC_MSG_NOTICE(quic module with kernel found and skip building it)
-	       AC_CHECK_FILE([/usr/include/linux/quic.h], [], [AC_MSG_ERROR([no kernel-headers found])])],
-	      [AC_SUBST([MODULES], [modules])
-	       AC_SUBST([KERNEL_BUILD], [$kernel/build])
-	       AC_SUBST([KERNEL_EXTRA], [$kernel/extra])
-	       AC_CHECK_FILE([$kernel/build/Makefile], [], [AC_MSG_ERROR(no kernel-devel found)])
-	       AC_CONFIG_FILES([modules/Makefile])])
+AC_ARG_WITH([modules], AS_HELP_STRING([--without-modules], [skip building kernel modules]))
+
+if test "x$with_modules" != "xno"; then
+	kernel="/lib/modules/`uname -r`"
+	if test -d "$kernel/kernel/net/quic" && test "x$with_modules" != "xyes" ; then
+		BUILTIN_MODULES=yes
+		AC_MSG_NOTICE([quic module found in kernel, skipping build])
+		test -f /usr/include/linux/quic.h || AC_MSG_ERROR([no kernel-headers found])
+	else
+		AC_SUBST([MODULES], [modules])
+		AC_SUBST([KERNEL_BUILD], [$kernel/build])
+		AC_SUBST([KERNEL_EXTRA], [$kernel/extra])
+		test -f "$kernel/build/Makefile" || AC_MSG_ERROR([no kernel-devel found])
+		AC_CONFIG_FILES([modules/Makefile])
+	fi
+else
+	AC_MSG_NOTICE([--without-modules specified, skipping kernel module build])
+fi
+
+AM_CONDITIONAL([BUILTIN_MODULES], [test "x$BUILTIN_MODULES" = "xyes"])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile libquic/Makefile libquic/libquic.pc tests/Makefile])

--- a/libquic/Makefile.am
+++ b/libquic/Makefile.am
@@ -3,13 +3,20 @@ EXTRA_DIST		= $(man7_MANS)
 
 lib_LTLIBRARIES		= libquic.la
 libquic_la_SOURCES	= client.c handshake.c server.c
-libquic_la_CPPFLAGS	= -I$(top_builddir)/libquic/ -I$(top_builddir)/modules/include/uapi/
+libquic_la_CPPFLAGS	= -I$(top_builddir)/libquic/
 libquic_la_CFLAGS	= -Werror -Wall $(LIBGNUTLS_CFLAGS)
 libquic_la_LIBADD	= $(LIBGNUTLS_LIBS)
 libquic_la_LDFLAGS	= -version-info 1:0:0
 
 libcnetinetdir		= $(includedir)/netinet
 libcnetinet_HEADERS	= netinet/quic.h
+
+if !BUILTIN_MODULES
+libquic_la_CPPFLAGS	+= -I$(top_builddir)/modules/include/uapi/
+
+libclinuxdir		= $(includedir)/linux
+libclinux_HEADERS	= $(top_builddir)/modules/include/uapi/linux/quic.h
+endif
 
 pkgconfigdir		= $(libdir)/pkgconfig
 pkgconfig_DATA		= libquic.pc

--- a/tests/interop/Dockerfile
+++ b/tests/interop/Dockerfile
@@ -9,9 +9,7 @@ RUN cd nghttp3 && autoreconf -i && ./configure --prefix=/usr/ && \
 
 RUN git clone https://github.com/lxin/quic
 RUN cd quic && ./autogen.sh && \
-    mkdir -p /lib/modules/`uname -r`/kernel/net/quic && \
-    install -m 644 modules/include/uapi/linux/quic.h /usr/include/linux && \
-    ./configure --prefix=/usr && make -j$(nproc) && make install && cd ..
+    ./configure --prefix=/usr --without-modules && make -j$(nproc) && make install && cd ..
 
 COPY interop_test.c interop_test.c
 RUN gcc interop_test.c -o interop_test -lnghttp3 -lquic -lgnutls && \


### PR DESCRIPTION
Previously, whether to build the QUIC kernel modules was determined automatically by checking if /lib/modules/$(uname -r)/kernel/net/quic existed, assuming the module was already built into the kernel.

This patch introduces a --with/without-modules configure option to let users explicitly control module building:

  --with-modules or --with-modules=yes: force building the modules

  --without-modules or --with-modules=no: skip building the modules

If this option is not provided, the build system will continue to detect module presence automatically using the existing logic.

Note: If QUIC is already built into the kernel, the system uses the existing header file at /usr/include/linux/quic.h to build libquic, and skips installing a duplicate copy in libquic/Makefile.am.

Additionally, fix the workaround in tests/interop/Dockerfile.