### PR TITLE
socket: implement SIOCINQ, SIOCOUTQ and SIOCOUTQNSD ioctls

### DIFF
--- a/modules/net/quic/output.h
+++ b/modules/net/quic/output.h
@@ -26,6 +26,7 @@ struct quic_outqueue {
 	u32 max_idle_timeout;
 	u32 stream_list_len;	/* all frames len in stream list */
 	u32 max_ack_delay;
+	u32 unsent_bytes;
 	u32 inflight;		/* all inflight ack_eliciting frames len */
 	u32 window;
 	u16 count;
@@ -50,6 +51,16 @@ struct quic_outqueue {
 	u8 force_delay:1;
 	u8 single:1;
 };
+
+static inline void quic_outq_dec_unsent_bytes(struct quic_outqueue *outq, u32 bytes)
+{
+	outq->unsent_bytes -= bytes;
+}
+
+static inline u32 quic_outq_unsent_bytes(struct quic_outqueue *outq)
+{
+	return outq->unsent_bytes;
+}
 
 static inline void quic_outq_inc_inflight(struct quic_outqueue *outq, u32 len)
 {

--- a/modules/net/quic/socket.c
+++ b/modules/net/quic/socket.c
@@ -12,6 +12,7 @@
 
 #include <net/inet_common.h>
 #include <linux/version.h>
+#include <asm/ioctls.h>
 #include <net/tls.h>
 
 #include "socket.h"
@@ -215,6 +216,36 @@ static void quic_sock_fetch_transport_param(struct sock *sk, struct quic_transpo
 	quic_conn_id_get_param(id_set, p);
 	quic_path_get_param(quic_paths(sk), p);
 	quic_stream_get_param(quic_streams(sk), p, quic_is_serv(sk));
+}
+
+static int quic_ioctl(struct sock *sk, int cmd, int *karg)
+{
+	int err = 0;
+
+	lock_sock(sk);
+
+	if (quic_is_listen(sk)) {
+		err = -EINVAL;
+		goto out;
+	}
+
+	switch (cmd) {
+	case SIOCINQ:
+		*karg = sk_rmem_alloc_get(sk);
+		break;
+	case SIOCOUTQ:
+		*karg = sk_wmem_alloc_get(sk);
+		break;
+	case SIOCOUTQNSD:
+		*karg = quic_outq_unsent_bytes(quic_outq(sk));
+		break;
+	default:
+		err = -ENOIOCTLCMD;
+		break;
+	}
+out:
+	release_sock(sk);
+	return err;
 }
 
 static int quic_init_sock(struct sock *sk)
@@ -2187,6 +2218,7 @@ out:
 struct proto quic_prot = {
 	.name		=  "QUIC",
 	.owner		=  THIS_MODULE,
+	.ioctl		=  quic_ioctl,
 	.init		=  quic_init_sock,
 	.destroy	=  quic_destroy_sock,
 	.shutdown	=  quic_shutdown,
@@ -2217,6 +2249,7 @@ struct proto quic_prot = {
 struct proto quicv6_prot = {
 	.name		=  "QUICv6",
 	.owner		=  THIS_MODULE,
+	.ioctl		=  quic_ioctl,
 	.init		=  quic_init_sock,
 	.destroy	=  quic_destroy_sock,
 	.shutdown	=  quic_shutdown,


### PR DESCRIPTION
This patch adds support for the ioctl API on QUIC sockets, implementing the following commands:

  SIOCINQ: returns the number of bytes in the receive queue.

  SIOCOUTQ: returns the number of bytes in the send queue.

  SIOCOUTQNSD: returns the number of unsent bytes.

To support SIOCOUTQNSD, a new unsent_bytes field is added to struct quic_outqueue. This counter is incremented when user data is enqueued in the send queue and decremented when bytes are actually sent.

Once the handshake is complete and the application uses only a single stream for sending and receiving, this ioctl interface behaves similarly to TCP.

Additionally, quic_outq_retransmit_list() no longer frees frames, as it is called only when sending has failed. These frames (including dgram and ping frames) should be retransmitted.