### PR TITLE
family: add ipv6 flowlabel support in quic_v6_lower_xmit

### DIFF
--- a/modules/net/quic/family.h
+++ b/modules/net/quic/family.h
@@ -25,9 +25,8 @@ bool quic_cmp_sk_addr(struct sock *sk, union quic_addr *a, union quic_addr *addr
 int quic_get_sk_addr(struct socket *sock, struct sockaddr *a, bool peer);
 void quic_set_sk_addr(struct sock *sk, union quic_addr *a, bool src);
 
-void quic_lower_xmit(struct sock *sk, struct sk_buff *skb, union quic_addr *da,
-		     union quic_addr *sa);
-int quic_flow_route(struct sock *sk, union quic_addr *da, union quic_addr *sa);
+void quic_lower_xmit(struct sock *sk, struct sk_buff *skb, union quic_addr *da, struct flowi *fl);
+int quic_flow_route(struct sock *sk, union quic_addr *da, union quic_addr *sa, struct flowi *fl);
 
 void quic_udp_conf_init(struct sock *sk, struct udp_port_cfg *conf, union quic_addr *a);
 int quic_get_mtu_info(struct sk_buff *skb, u32 *info);

--- a/modules/net/quic/path.c
+++ b/modules/net/quic/path.c
@@ -201,6 +201,7 @@ static int quic_path_set_bind_port(struct sock *sk, struct quic_path_group *path
 		addr->v4.sin_port = htons(snum);
 		port->net = net;
 		port->port = snum;
+		__sk_dst_reset(sk);
 		hlist_add_head(&port->node, &head->head);
 		spin_unlock_bh(&head->lock);
 		return 0;

--- a/modules/net/quic/path.h
+++ b/modules/net/quic/path.h
@@ -46,6 +46,7 @@ struct quic_path_group {
 	struct quic_conn_id retry_dcid;
 	struct quic_conn_id orig_dcid;
 	struct quic_path path[2];
+	struct flowi fl;
 	u16 ampl_sndlen; /* amplificationlimit send counting */
 	u16 ampl_rcvlen; /* amplificationlimit recv counting */
 	u8 entropy[8];
@@ -74,6 +75,11 @@ struct quic_path_group {
 	u8 retry:1;
 	u8 serv:1;
 };
+
+static inline struct flowi *quic_path_flowi(struct quic_path_group *paths)
+{
+	return &paths->fl;
+}
 
 static inline union quic_addr *quic_path_saddr(struct quic_path_group *paths, u8 path)
 {


### PR DESCRIPTION
This patch adds the support for IPv6 flow labels.

It introduces a paths->fl field to store the 4-tuple in quic_flow_route(), which is then used in quic_v6_lower_xmit() to generate a flow label via ip6_make_flowlabel() if fl6->flowlabel was not set.

Applications can also provide an explicit IPv6 flow label by setting it in the address passed to connect(), after enabling the socket option IPV6_FLOWINFO_SEND (e.g., via setsockopt() with IPPROTO_IPV6).

Reported-by: Stefan Metzmacher <metze@samba.org>