### PR TITLE
Add stream peeloff support

### DIFF
--- a/modules/include/uapi/linux/quic.h
+++ b/modules/include/uapi/linux/quic.h
@@ -86,6 +86,8 @@ struct quic_stream_info {
 #define QUIC_SOCKOPT_CRYPTO_SECRET			13
 #define QUIC_SOCKOPT_TRANSPORT_PARAM_EXT		14
 
+#define QUIC_SOCKOPT_STREAM_PEELOFF			15
+
 #define QUIC_VERSION_V1			0x1
 #define QUIC_VERSION_V2			0x6b3343cf
 
@@ -152,6 +154,12 @@ struct quic_connection_id_info {
 struct quic_event_option {
 	__u8	type;
 	__u8	on;
+};
+
+struct quic_stream_peeloff {
+	__s64	stream_id;
+	__u32	flags;
+	int	sd;
 };
 
 /* Event APIs */

--- a/modules/net/quic/frame.c
+++ b/modules/net/quic/frame.c
@@ -1385,6 +1385,7 @@ static int quic_frame_reset_stream_process(struct sock *sk, struct quic_frame *f
 	 */
 	quic_inq_list_purge(sk, &inq->stream_list, stream);
 	quic_inq_list_purge(sk, &inq->recv_list, stream);
+	quic_inq_list_purge(sk, &stream->recv.frame_list, NULL);
 	quic_stream_recv_put(streams, stream, quic_is_serv(sk)); /* Release the receive stream. */
 out:
 	return (int)(frame->len - len);

--- a/modules/net/quic/protocol.c
+++ b/modules/net/quic/protocol.c
@@ -171,6 +171,179 @@ static __poll_t quic_inet_poll(struct file *file, struct socket *sock, poll_tabl
 	return mask;
 }
 
+static int quic_stream_shutdown(struct socket *sock, int how)
+{
+	struct quic_stream_sock *ssk = quic_ssk(sock->sk);
+	struct quic_stream *stream = ssk->stream;
+	struct quic_errinfo info = {};
+	struct sock *sk = ssk->sk;
+	struct msghdr msg = {};
+	bool is_serv;
+	int err = 0;
+
+	if ((how & ~SHUTDOWN_MASK) || !how)
+		return -EINVAL;
+
+	lock_sock(sk);
+	quic_inq_list_purge(sk, &stream->recv.frame_list, NULL);
+
+	if (quic_is_closed(sk)) {
+		err = -EPIPE;
+		goto out;
+	}
+
+	is_serv = quic_is_serv(sk);
+	if ((how & SEND_SHUTDOWN) && quic_stream_id_send(stream->id, is_serv))
+		quic_sock_sendmsg(sk, &msg, 0, MSG_STREAM_FIN, stream->id);
+
+	if ((how & RCV_SHUTDOWN) && quic_stream_id_recv(stream->id, is_serv)) {
+		info.stream_id = stream->id;
+		quic_kernel_setsockopt(sk, QUIC_SOCKOPT_STREAM_STOP_SENDING, &info, sizeof(info));
+	}
+out:
+	release_sock(sk);
+	return err;
+}
+
+static int quic_stream_release(struct socket *sock)
+{
+	struct quic_stream_sock *ssk = quic_ssk(sock->sk);
+	struct quic_stream *stream = ssk->stream;
+	struct quic_errinfo info = {};
+	struct sock *sk = ssk->sk;
+	struct msghdr msg = {};
+	bool is_serv;
+
+	if (!stream->peeled) /* Happens if peeling the stream failed. */
+		goto free;
+
+	lock_sock(sk);
+	stream->peeled = 0; /* Unmark stream as peeled in case parent sk handle the clenup. */
+	quic_inq_list_purge(sk, &stream->recv.frame_list, NULL);
+	if (hlist_unhashed(&stream->node)) { /* Free stream if already released by parent sk. */
+		kfree(stream);
+		goto out;
+	}
+
+	if (quic_is_closed(sk)) /* If connection closed, let parent handle cleanup. */
+		goto out;
+
+	is_serv = quic_is_serv(sk);
+	if (quic_stream_id_send(stream->id, is_serv))
+		quic_sock_sendmsg(sk, &msg, 0, MSG_STREAM_FIN, stream->id);
+
+	if (quic_stream_id_recv(stream->id, is_serv)) {
+		if (stream->recv.state == QUIC_STREAM_RECV_STATE_RECVD) {
+			/* All frames purged; mark stream as fully read and release it. */
+			stream->recv.state = QUIC_STREAM_RECV_STATE_READ;
+			quic_stream_recv_put(quic_streams(sk), stream, is_serv);
+			goto out;
+		}
+		info.stream_id = stream->id;
+		quic_kernel_setsockopt(sk, QUIC_SOCKOPT_STREAM_STOP_SENDING, &info, sizeof(info));
+	}
+out:
+	release_sock(sk);
+	sock_put(sk); /* Release reference to parent sk. */
+free:
+	sock_put(sock->sk);
+	sock->sk = NULL;
+	return 0;
+}
+
+static __poll_t quic_stream_poll(struct file *file, struct socket *sock, poll_table *wait)
+{
+	struct quic_stream_sock *ssk = quic_ssk(sock->sk);
+	struct quic_stream *stream = ssk->stream;
+	struct sock *sk = ssk->sk;
+	__poll_t mask = 0;
+
+	poll_wait(file, sk_sleep(sk), wait);
+
+	if (quic_is_closed(sk)) {
+		/* A broken connection should report almost everything in order to let
+		 * applications to detect it reliable.
+		 */
+		mask |= EPOLLHUP;
+		mask |= EPOLLERR;
+		mask |= EPOLLIN | EPOLLRDNORM | EPOLLRDHUP;
+		mask |= EPOLLOUT | EPOLLWRNORM;
+		return mask;
+	}
+
+	if (quic_stream_id_recv(stream->id, quic_is_serv(sk))) { /* Readable check. */
+		if (stream->recv.state >= QUIC_STREAM_RECV_STATE_READ ||
+		    !list_empty(&stream->recv.frame_list))
+			mask |= EPOLLIN | EPOLLRDNORM;
+	}
+
+	if (!quic_stream_id_send(stream->id, quic_is_serv(sk)))
+		return mask;
+
+	if (stream->send.state >= QUIC_STREAM_SEND_STATE_SENT ||
+	    (sk_stream_wspace(sk) > 0 && quic_outq_wspace(sk, stream)) > 0) { /* Writable check. */
+		mask |= EPOLLOUT | EPOLLWRNORM;
+	} else {
+		sk_set_bit(SOCKWQ_ASYNC_NOSPACE, sk);
+		/* Do writeable check again after the bit is set to avoid a lost I/O signal,
+		 * similar to sctp_poll().
+		 */
+		if (sk_stream_wspace(sk) > 0 && quic_outq_wspace(sk, stream) > 0)
+			mask |= EPOLLOUT | EPOLLWRNORM;
+	}
+	return mask;
+}
+
+static int quic_stream_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
+{
+	struct quic_stream_sock *ssk = quic_ssk(sock->sk);
+	struct quic_stream *stream = ssk->stream;
+	struct sock *sk = ssk->sk;
+	int err = 0;
+
+	lock_sock(sk);
+	if (quic_is_closed(sk)) {
+		err = -EPIPE;
+		goto out;
+	}
+	if (!quic_stream_id_send(stream->id, quic_is_serv(sk))) {
+		err = -EINVAL;
+		goto out;
+	}
+	if (stream->send.state >= QUIC_STREAM_SEND_STATE_SENT) { /* All data sent. */
+		err = -EINVAL;
+		goto out;
+	}
+	err = quic_sock_sendmsg(sk, msg, size, msg->msg_flags & MSG_STREAM_FIN, stream->id);
+out:
+	release_sock(sk);
+	return err;
+}
+
+static int quic_stream_recvmsg(struct socket *sock, struct msghdr *msg, size_t size, int flags)
+{
+	struct quic_stream_sock *ssk = quic_ssk(sock->sk);
+	struct quic_stream *stream = ssk->stream;
+	struct sock *sk = ssk->sk;
+	int err = 0;
+
+	lock_sock(sk);
+	if (quic_is_closed(sk)) {
+		err = -EPIPE;
+		goto out;
+	}
+	if (!quic_stream_id_recv(stream->id, quic_is_serv(sk))) {
+		err = -EINVAL;
+		goto out;
+	}
+	if (stream->recv.state >= QUIC_STREAM_RECV_STATE_READ) /* All data read. */
+		goto out;
+	err = quic_sock_recvmsg(sk, msg, size, flags, stream->id);
+out:
+	release_sock(sk);
+	return err;
+}
+
 static struct ctl_table quic_table[] = {
 	{
 		.procname	= "quic_mem",
@@ -359,6 +532,49 @@ static void quic_transport_param_init(void)
 	p->max_stream_data_uni = (u64)QUIC_PATH_MAX_PMTU * 16;
 	p->max_streams_bidi = QUIC_DEF_STREAMS;
 	p->max_streams_uni = QUIC_DEF_STREAMS;
+}
+
+static const struct proto_ops quic_stream_ops = {
+	.owner		   = THIS_MODULE,
+	.release	   = quic_stream_release,
+	.bind		   = sock_no_bind,
+	.connect	   = sock_no_connect,
+	.socketpair	   = sock_no_socketpair,
+	.accept		   = sock_no_accept,
+	.getname	   = sock_no_getname,
+	.poll		   = quic_stream_poll,
+	.ioctl		   = sock_no_ioctl,
+	.listen		   = sock_no_listen,
+	.shutdown	   = quic_stream_shutdown,
+	.sendmsg	   = quic_stream_sendmsg,
+	.recvmsg	   = quic_stream_recvmsg,
+	.mmap		   = sock_no_mmap,
+};
+
+struct socket *quic_inet_stream_sock_alloc(struct sock *sk, struct quic_stream *stream)
+{
+	struct quic_stream_sock *ssk;
+	struct socket *sock;
+	struct sock *nsk;
+
+	nsk = sk_alloc(sock_net(sk), sk->sk_family, GFP_KERNEL, &quic_stream_prot, 0);
+	if (!nsk)
+		return NULL;
+	ssk = quic_ssk(nsk);
+	ssk->sk = sk;
+	ssk->stream = stream;
+
+	sock = sock_alloc();
+	if (!sock) {
+		sk_free(nsk);
+		return NULL;
+	}
+	sock->type = SOCK_RAW;
+	sock->ops = &quic_stream_ops;
+	sock_init_data(sock, nsk);
+	__module_get(sock->ops->owner);
+
+	return sock;
 }
 
 static const struct proto_ops quic_proto_ops = {

--- a/modules/net/quic/protocol.h
+++ b/modules/net/quic/protocol.h
@@ -57,6 +57,7 @@ struct quic_net {
 	struct work_struct work;	/* Work scheduled to drain and process backlog_list */
 };
 
+struct socket *quic_inet_stream_sock_alloc(struct sock *sk, struct quic_stream *stream);
 struct quic_net *quic_net(struct net *net);
 
 #define QUIC_INC_STATS(net, field)	SNMP_INC_STATS(quic_net(net)->stat, field)

--- a/modules/net/quic/socket.h
+++ b/modules/net/quic/socket.h
@@ -30,6 +30,7 @@
 
 extern struct proto quic_prot;
 extern struct proto quicv6_prot;
+extern struct proto quic_stream_prot;
 
 enum quic_state {
 	QUIC_SS_CLOSED		= TCP_CLOSE,
@@ -79,6 +80,12 @@ struct quic_request_sock {
 	u32			blen;
 };
 
+struct quic_stream_sock {
+	struct sock		common;
+	struct quic_stream	*stream;
+	struct sock		*sk;
+};
+
 struct quic_sock {
 	struct inet_sock		inet;
 	struct list_head		reqs;
@@ -115,6 +122,11 @@ static inline struct quic_sock *quic_sk(const struct sock *sk)
 static inline struct list_head *quic_reqs(const struct sock *sk)
 {
 	return &quic_sk(sk)->reqs;
+}
+
+static inline struct quic_stream_sock *quic_ssk(const struct sock *sk)
+{
+	return (struct quic_stream_sock *)sk;
 }
 
 static inline struct quic_config *quic_config(const struct sock *sk)
@@ -258,3 +270,8 @@ struct quic_request_sock *quic_request_sock_enqueue(struct sock *sk, struct quic
 int quic_request_sock_backlog_tail(struct sock *sk, struct quic_request_sock *req,
 				   struct sk_buff *skb);
 struct quic_request_sock *quic_request_sock_lookup(struct sock *sk);
+
+int quic_sock_sendmsg(struct sock *sk, struct msghdr *msg, size_t msg_len, int flags,
+		      s64 stream_id);
+int quic_sock_recvmsg(struct sock *sk, struct msghdr *msg, size_t msg_len, int flags,
+		      s64 stream_id);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST		= keys runtest.sh
 
-noinst_PROGRAMS		= func_test perf_test sample_test ticket_test alpn_test
+noinst_PROGRAMS		= func_test perf_test sample_test ticket_test alpn_test peeloff_test
 
 AM_CPPFLAGS		= -I$(top_builddir)/libquic/ -I$(top_builddir)/modules/include/uapi/
 AM_CFLAGS		= -Werror -Wall -Wformat-signedness $(LIBGNUTLS_CFLAGS)
@@ -11,6 +11,7 @@ perf_test_SOURCE	= perf_test.c
 alpn_test_SOURCE	= alpn_test.c
 ticket_test_SOURCE	= ticket_test.c
 sample_test_SOURCE	= sample_test.c
+peeloff_test_SOURCE	= peeloff_test.c
 
 http3_test: http3_test.c
 	$(LIBTOOL) --mode=link $(CC) $^  -o $@ -lnghttp3 \

--- a/tests/peeloff_test.c
+++ b/tests/peeloff_test.c
@@ -1,0 +1,206 @@
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/quic.h>
+#include <sys/syslog.h>
+
+static const char *parse_address(char *address, char const *port, struct sockaddr_storage *sas)
+{
+	struct addrinfo hints = {0};
+	struct addrinfo *res;
+	int rc;
+
+	hints.ai_flags = AI_NUMERICHOST|AI_NUMERICSERV;
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+
+	rc = getaddrinfo(address, port, &hints, &res);
+	if (rc != 0)
+		return gai_strerror(rc);
+	memcpy(sas, res->ai_addr, res->ai_addrlen);
+	freeaddrinfo(res);
+	return NULL;
+}
+
+static int do_client(int argc, char *argv[])
+{
+	struct quic_stream_peeloff pinfo = {};
+	struct quic_stream_info sinfo = {};
+	struct sockaddr_storage ra = {};
+	int ret, sockfd, strmfd;
+	unsigned int optlen;
+	const char *rc;
+	char msg[50];
+
+	if (argc < 3) {
+		printf("%s client <PEER ADDR> <PEER PORT>\n", argv[0]);
+		return 0;
+	}
+
+	rc = parse_address(argv[2], argv[3], &ra);
+	if (rc != NULL) {
+		printf("parse address failed: %s\n", rc);
+		return -1;
+	}
+	sockfd = socket(ra.ss_family, SOCK_DGRAM, IPPROTO_QUIC);
+	if (sockfd < 0) {
+		printf("socket create failed\n");
+		return -1;
+	}
+
+	if (connect(sockfd, (struct sockaddr *)&ra, sizeof(ra))) {
+		printf("socket connect failed\n");
+		return -1;
+	}
+
+	if (quic_client_handshake(sockfd, NULL, NULL, NULL))
+		return -1;
+
+	/* open a unidirectional stream */
+	optlen = sizeof(sinfo);
+	sinfo.stream_id = -1;
+	sinfo.stream_flags = MSG_STREAM_UNI;
+	ret = getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_STREAM_OPEN, &sinfo, &optlen);
+	if (ret) {
+		printf("getsockopt stream_open failed\n");
+		return -1;
+	}
+
+	/* peel off the stream */
+	optlen = sizeof(pinfo);
+	pinfo.stream_id = sinfo.stream_id;
+	strmfd = getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_STREAM_PEELOFF, &pinfo, &optlen);
+	if (strmfd < 0) {
+		printf("getsockopt stream_peeloff failed %d\n", strmfd);
+		return -1;
+	}
+
+	/* send data on the peeled off stream */
+	strcpy(msg, "hello quic server!");
+	ret = send(strmfd, msg, strlen(msg), 0);
+	if (ret == -1) {
+		printf("send error %d %d\n", ret, errno);
+		return -1;
+	}
+	printf("send '%s' on stream %d\n", msg, (int)pinfo.stream_id);
+	close(strmfd);
+
+	recv(sockfd, NULL, 0, 0);
+	close(sockfd);
+	return 0;
+}
+
+static int do_server(int argc, char *argv[])
+{
+	struct quic_stream_peeloff pinfo = {};
+	unsigned int addrlen, flags, optlen;
+	int listenfd, sockfd, strmfd, ret;
+	struct sockaddr_storage sa = {};
+	struct quic_event_option event;
+	union quic_event *ev;
+	const char *rc;
+	char msg[50];
+
+	if (argc < 5) {
+		printf("%s server <LOCAL ADDR> <LOCAL PORT> <PRIVATE_KEY_FILE> "
+		       "<CERTIFICATE_FILE>\n", argv[0]);
+		return 0;
+	}
+
+	rc = parse_address(argv[2], argv[3], &sa);
+	if (rc != NULL) {
+		printf("parse address failed: %s\n", rc);
+		return -1;
+	}
+	listenfd = socket(sa.ss_family, SOCK_DGRAM, IPPROTO_QUIC);
+	if (listenfd < 0) {
+		printf("socket create failed\n");
+		return -1;
+	}
+	if (bind(listenfd, (struct sockaddr *)&sa, sizeof(sa))) {
+		printf("socket bind failed\n");
+		return -1;
+	}
+	if (listen(listenfd, 1)) {
+		printf("socket listen failed\n");
+		return -1;
+	}
+	addrlen = sizeof(sa);
+	sockfd = accept(listenfd, (struct sockaddr *)&sa, &addrlen);
+	if (sockfd < 0) {
+		printf("socket accept failed %d %d\n", errno, sockfd);
+		return -1;
+	}
+
+	if (quic_server_handshake(sockfd, argv[4], argv[5], NULL))
+		return -1;
+
+	/* enable stream update event */
+	event.type = QUIC_EVENT_STREAM_UPDATE;
+	event.on = 1;
+	ret = setsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_EVENT, &event, sizeof(event));
+	if (ret == -1) {
+		printf("socket setsockopt event error %d\n", errno);
+		return -1;
+	}
+
+	while (1) {
+		/* wait for stream update event for new recv stream */
+		flags = 0;
+		memset(msg, 0, sizeof(msg));
+		ret = quic_recvmsg(sockfd, msg, sizeof(msg) - 1, NULL, &flags);
+		if (ret == -1) {
+			printf("recv error %d %d\n", ret, errno);
+			return 1;
+		}
+		if (!(flags & MSG_NOTIFICATION) || msg[0] != QUIC_EVENT_STREAM_UPDATE)
+			continue;
+		ev = (union quic_event *)&msg[1];
+		if (ev->update.state != QUIC_STREAM_RECV_STATE_RECV)
+			continue;
+
+		/* peel off the stream */
+		optlen = sizeof(pinfo);
+		pinfo.stream_id = ev->update.id;
+		strmfd = getsockopt(sockfd, SOL_QUIC, QUIC_SOCKOPT_STREAM_PEELOFF, &pinfo, &optlen);
+		if (strmfd < 0) {
+			printf("getsockopt stream_peeloff failed %d\n", ret);
+			return -1;
+		}
+
+		/* read data from the peeled off stream */
+		memset(msg, 0, sizeof(msg));
+		ret = recv(strmfd, msg, sizeof(msg) - 1, 0);
+		if (ret == -1) {
+			printf("recv error %d %d\n", ret, errno);
+			return 1;
+		}
+		printf("recv '%s' on stream %d\n", msg, (int)pinfo.stream_id);
+		close(strmfd);
+		break;
+	}
+
+	close(sockfd);
+	close(listenfd);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2 || (strcmp(argv[1], "server") && strcmp(argv[1], "client"))) {
+		printf("%s server|client ...\n", argv[0]);
+		return 0;
+	}
+
+	quic_set_log_level(LOG_NOTICE);
+
+	if (!strcmp(argv[1], "client"))
+		return do_client(argc, argv);
+
+	return do_server(argc, argv);
+}

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -31,6 +31,7 @@ cleanup()
 	pkill alpn_test > /dev/null 2>&1
 	pkill ticket_test > /dev/null 2>&1
 	pkill sample_test > /dev/null 2>&1
+	pkill peeloff_test > /dev/null 2>&1
 	pkill http3_test > /dev/null 2>&1
 	rmmod quic_sample_test > /dev/null 2>&1
 	rmmod quic > /dev/null 2>&1
@@ -291,7 +292,15 @@ sample_tests()
 
 }
 
-TESTS="func perf netem http3 tlshd alpn ticket sample"
+peeloff_tests()
+{
+	print_start "Stream Peeloff Tests"
+	daemon_run ./peeloff_test server 0.0.0.0 1234 ./keys/server-key.pem ./keys/server-cert.pem
+	./peeloff_test  client 127.0.0.1 1234 || return 1
+	daemon_stop "sample_test"
+}
+
+TESTS="func perf netem http3 tlshd alpn ticket sample peeloff"
 trap cleanup EXIT
 
 [ "$1" = "" ] || TESTS=$1


### PR DESCRIPTION
The 1st patch introduces a new socket option, QUIC_SOCKOPT_STREAM_PEELOFF, allowing applications to "peel off" an individual QUIC stream from a connection and obtain a dedicated socket for it.

The 2nd patch adds a sample test case demonstrating the use of the QUIC_SOCKOPT_STREAM_PEELOFF socket option, and the APIs of stream sockets.