### PR TITLE
Add crypto offload support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,11 @@ if test "x$with_modules" != "xno"; then
 		AC_SUBST([KERNEL_EXTRA], [$kernel/extra])
 		test -f "$kernel/build/Makefile" || AC_MSG_ERROR([no kernel-devel found])
 		AC_CONFIG_FILES([modules/Makefile])
+
+		if test -f "$KERNEL_BUILD/include/linux/quic_offload.h"; then
+			AC_MSG_NOTICE([quic offload is enabled])
+			AC_SUBST([QUIC_OFFLOAD_FLAGS], [-DQUIC_OFFLOAD])
+		fi
 	fi
 else
 	AC_MSG_NOTICE([--without-modules specified, skipping kernel module build])

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -3,7 +3,8 @@ MODULES		= quic_unit_test quic_sample_test quic
 
 all:
 	$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR)/net/quic modules \
-		ROOTDIR=$(CURDIR) CONFIG_IP_QUIC=m CONFIG_IP_QUIC_TEST=m
+		ROOTDIR=$(CURDIR) CONFIG_IP_QUIC=m CONFIG_IP_QUIC_TEST=m \
+		KCFLAGS="$(QUIC_OFFLOAD_FLAGS)"
 
 install: uninstall_modules install_headers install_modules depmod
 

--- a/modules/net/quic/crypto.h
+++ b/modules/net/quic/crypto.h
@@ -51,6 +51,8 @@ struct quic_crypto {
 	u32 version;				/* QUIC version in use */
 
 	u8 ticket_ready:1;			/* True if  a session ticket is ready to read */
+	u8 send_offload:1;			/* True if HW offload for send is enabled */
+	u8 recv_offload:1;			/* True if HW offload for recv is enabled */
 	u8 key_pending:1;			/* A key update is in progress */
 	u8 send_ready:1;			/* TX encryption context is initialized */
 	u8 recv_ready:1;			/* RX decryption context is initialized */

--- a/modules/net/quic/crypto.h
+++ b/modules/net/quic/crypto.h
@@ -39,6 +39,10 @@ struct quic_crypto {
 
 	u8 tx_secret[QUIC_SECRET_LEN];		/* TX secret derived or provided by user space */
 	u8 rx_secret[QUIC_SECRET_LEN];		/* RX secret derived or provided by user space */
+	u8 tx_hp_key[QUIC_KEY_LEN];		/* Header KEY for TX */
+	u8 rx_hp_key[QUIC_KEY_LEN];		/* Header KEY for RX */
+	u8 tx_key[2][QUIC_KEY_LEN];		/* KEYs for TX (key phase 0 and 1) */
+	u8 rx_key[2][QUIC_KEY_LEN];		/* KEYs for RX (key phase 0 and 1) */
 	u8 tx_iv[2][QUIC_IV_LEN];		/* IVs for TX (key phase 0 and 1) */
 	u8 rx_iv[2][QUIC_IV_LEN];		/* IVs for RX (key phase 0 and 1) */
 


### PR DESCRIPTION
This patch introduces support for QUIC crypto offload, allowing the driver to program NIC hardware with encryption keys and initialization vectors. This enables the NIC to handle QUIC record encryption and decryption directly.

This is currently a draft implementation intended to test hardware offload functionality. It depends on the kernel changes from [lxin/net-next: quic-offload](https://github.com/lxin/net-next/commits/quic-offload), and is being tested on select Broadcom bnxt NICs.