### PR TITLE
Fixes for issues in includes/netinet/quic.h

### DIFF
--- a/libquic/netinet/quic.h
+++ b/libquic/netinet/quic.h
@@ -17,6 +17,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>
  */
 
+#ifndef _NETINET_QUIC_H
+#define _NETINET_QUIC_H
+
 #include <gnutls/abstract.h>
 #include <sys/socket.h>
 #include <linux/quic.h>
@@ -102,3 +105,5 @@ int quic_set_log_level(int level);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _NETINET_QUIC_H */


### PR DESCRIPTION
This pull request fixes the issues of https://github.com/lxin/quic/issues/59:

1.  Adding the missing linkage specification
2. Putting the declarations into an "#ifndef _NETINET_QUIC_H ... #endif" block
