### PR TITLE
Support IP/IPv6 options building on TX path

### DIFF
--- a/modules/net/quic/family.h
+++ b/modules/net/quic/family.h
@@ -15,8 +15,8 @@
 #define QUIC_PREF_ADDR_LEN	(QUIC_ADDR4_LEN + QUIC_PORT_LEN + QUIC_ADDR6_LEN + QUIC_PORT_LEN)
 
 void quic_seq_dump_addr(struct seq_file *seq, union quic_addr *addr);
+u32 quic_encap_len(struct sock *sk, union quic_addr *a);
 int quic_is_any_addr(union quic_addr *a);
-u32 quic_encap_len(union quic_addr *a);
 
 void quic_lower_xmit(struct sock *sk, struct sk_buff *skb, union quic_addr *da, struct flowi *fl);
 int quic_flow_route(struct sock *sk, union quic_addr *da, union quic_addr *sa, struct flowi *fl);

--- a/modules/net/quic/packet.c
+++ b/modules/net/quic/packet.c
@@ -670,7 +670,7 @@ static int quic_packet_retry_create(struct sock *sk)
 	quic_conn_id_generate(&conn_id); /* Generate new SCID for the Retry packet. */
 	/* Compute total packet length: header + token + integrity tag. */
 	len = QUIC_LONG_HLEN(&conn_id, &packet->scid) + tlen + QUIC_TAG_LEN;
-	hlen = quic_encap_len(da) + MAX_HEADER;
+	hlen = quic_encap_len(sk, da) + MAX_HEADER;
 	skb = alloc_skb(hlen + len, GFP_ATOMIC);
 	if (!skb)
 		return -ENOMEM;
@@ -745,7 +745,7 @@ static int quic_packet_version_create(struct sock *sk)
 
 	/* Compute packet length: header + supported version list. */
 	len = QUIC_LONG_HLEN(&packet->dcid, &packet->scid) + QUIC_VERSION_LEN * QUIC_VERSION_NUM;
-	hlen = quic_encap_len(da) + MAX_HEADER;
+	hlen = quic_encap_len(sk, da) + MAX_HEADER;
 	skb = alloc_skb(hlen + len, GFP_ATOMIC);
 	if (!skb)
 		return -ENOMEM;
@@ -818,7 +818,7 @@ static int quic_packet_stateless_reset_create(struct sock *sk)
 		return -EINVAL;
 
 	len = QUIC_STATELESS_RESET_DEF_LEN;
-	hlen = quic_encap_len(da) + MAX_HEADER;
+	hlen = quic_encap_len(sk, da) + MAX_HEADER;
 	skb = alloc_skb(hlen + len, GFP_ATOMIC);
 	if (!skb)
 		return -ENOMEM;
@@ -2268,7 +2268,7 @@ int quic_packet_route(struct sock *sk)
 	if (err)
 		return err;
 
-	packet->hlen = quic_encap_len(da);
+	packet->hlen = quic_encap_len(sk, da);
 	pmtu = min_t(u32, dst_mtu(__sk_dst_get(sk)), QUIC_PATH_MAX_PMTU);
 	quic_packet_mss_update(sk, pmtu - packet->hlen);
 


### PR DESCRIPTION
When users configure IP or IPv6 options via setsockopt(), the transmit path must reserve sufficient headroom to accommodate these options. This patch ensures that space is correctly reserved so IP/IPv6 options can be built during transmission.

Note that full IP/IPv6 options support on the TX path also requires corresponding changes in the UDP tunnel transmit code, see [lxin/net-next: ip-options](https://github.com/lxin/net-next/commits/ip-options).