### PR TITLE
outqueue: bundle pending delayed ACK with outgoing stream data

### DIFF
--- a/modules/net/quic/outqueue.c
+++ b/modules/net/quic/outqueue.c
@@ -233,9 +233,11 @@ static bool quic_outq_delay_check(struct sock *sk, u8 level, bool nodelay)
 /* Sends stream data frames. */
 static void quic_outq_transmit_stream(struct sock *sk)
 {
+	struct quic_pnspace *space = quic_pnspace(sk, QUIC_CRYPTO_APP);
 	struct quic_outqueue *outq = quic_outq(sk);
 	struct quic_frame *frame, *next;
 	struct list_head *head;
+	bool sent = false;
 
 	/* Although frame->level is always App, stream data may need to be sent
 	 * at App or Early level depending on key availability. Use
@@ -253,11 +255,20 @@ static void quic_outq_transmit_stream(struct sock *sk)
 		if (quic_outq_delay_check(sk, outq->data_level, frame->nodelay))
 			break;
 		if (quic_packet_tail(sk, frame)) {
+			sent = true;
 			outq->stream_list_len -= frame->len;
 			continue;
 		}
 		outq->count += quic_packet_create_and_xmit(sk);
 		next = frame;
+	}
+
+	/* Bundle an ACK frame if there is a pending delayed ACK. */
+	if (sent && space->sack_pending) {
+		space->need_sack = 1;
+		space->sack_path = 0;
+		space->sack_pending = 0;
+		quic_outq_transmit_ctrl(sk, QUIC_CRYPTO_APP);
 	}
 }
 

--- a/modules/net/quic/packet.c
+++ b/modules/net/quic/packet.c
@@ -1817,9 +1817,11 @@ static int quic_packet_app_process_done(struct sock *sk, struct sk_buff *skb)
 	if (!packet->ack_eliciting)
 		goto out; /* No ACK-eliciting frame: skip ACK. */
 
-	if (packet->ack_immediate || cb->number < space->max_pn_seen) {
+	if (packet->ack_immediate || cb->number < space->max_pn_seen ||
+	    cb->path) {
 		space->need_sack = 1; /* ACK needed for this packet space. */
 		space->sack_path = cb->path; /* ACK on same path as packet. */
+		space->sack_pending = 0;
 		goto out;
 	}
 
@@ -1829,6 +1831,7 @@ static int quic_packet_app_process_done(struct sock *sk, struct sk_buff *skb)
 	if (inq->sack_flag == QUIC_SACK_FLAG_NONE)
 		quic_timer_reset(sk, QUIC_TIMER_SACK, inq->max_ack_delay);
 	inq->sack_flag = QUIC_SACK_FLAG_APP;
+	space->sack_pending = 1;
 
 out:
 	if (quic_is_established(sk)) {

--- a/modules/net/quic/pnspace.h
+++ b/modules/net/quic/pnspace.h
@@ -66,6 +66,7 @@ struct quic_pnspace {
 	u16 pn_map_len;        /* Length of the PN bit map (in bits) */
 	u8  need_sack;         /* Flag indicating a SACK frame should be sent */
 	u8  sack_path;         /* Path used for sending the SACK frame */
+	u8  sack_pending;      /* Delayed ACK pending */
 
 	s64 last_max_pn_seen; /* Largest PN seen before pn_map advance */
 	u64 last_max_pn_time; /* Timestamp last_max_pn_seen was received */

--- a/modules/net/quic/timer.c
+++ b/modules/net/quic/timer.c
@@ -52,9 +52,10 @@ void quic_timer_sack_handler(struct sock *sk)
 		return;
 	}
 
-	if (inq->sack_flag == QUIC_SACK_FLAG_APP) {
+	if (inq->sack_flag == QUIC_SACK_FLAG_APP && space->sack_pending) {
 		space->need_sack = 1; /* Request APP-level ACK. */
 		space->sack_path = 0; /* Send ACK on active path. */
+		space->sack_pending = 0;
 	}
 
 	quic_outq_transmit(sk); /* Transmit queued frames, including ACKs. */


### PR DESCRIPTION
When transmitting STREAM frames at the application level, we may have a delayed ACK pending in the same packet number space. In request/response style workloads, waiting for the delayed ACK timer can introduce unnecessary latency.

Track whether stream data was actually appended to a packet during quic_outq_transmit_stream(), and if so, check whether an application level delayed ACK is pending. If it is, mark need_sack and trigger control transmission so the ACK can be piggybacked on outgoing data.

This avoids forcing immediate ACKs globally while still reducing latency for interactive or echo-style traffic patterns.