### PR TITLE
libquic: Fix NULL dereference in quic_handshake_step()

### DIFF
--- a/libquic/handshake.c
+++ b/libquic/handshake.c
@@ -835,9 +835,13 @@ int quic_handshake_step(gnutls_session_t session,
 			struct quic_handshake_step **pstep)
 {
 	struct quic_handshake_ctx *ctx = quic_handshake_ctx_get(session);
-	quic_handshake_step_process_fn_t process_fn = ctx->next_step.process_fn;
+	quic_handshake_step_process_fn_t process_fn;
 	int ret;
 
+	if (ctx == NULL)
+		return -EINVAL;
+
+	process_fn = ctx->next_step.process_fn;
 	ctx->next_step.process_fn = NULL;
 
 	if (pstep == NULL)


### PR DESCRIPTION
When _quic_handshake_ctx_get()_ returns NULL, the function immediately dereferences _ctx_ without checking, causing a NULL pointer dereference and SIGSEGV. Add NULL check immediately after getting _ctx_, before any dereference and defer initialization of _process_fn_ until after the NULL check.