### PR TITLE
Fix for broken determination of quic_recvmsg() call signature

### DIFF
--- a/modules/net/quic/socket.c
+++ b/modules/net/quic/socket.c
@@ -1294,7 +1294,7 @@ static int quic_wait_for_packet(struct sock *sk, struct list_head *head,
 	return err;
 }
 
-#ifdef IP_TUNNEL_RECURSION_LIMIT
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
 static int quic_recvmsg(struct sock *sk, struct msghdr *msg, size_t msg_len,
 			int flags)
 #else


### PR DESCRIPTION
The call signature of quic_recvmsg() changed in kernel 7.1. However, the QUIC code used `#ifdef IP_TUNNEL_RECURSION_LIMIT` to determine the call signature variant => compiling the QUIC module fails under kernel 7.0.14 (e.g. Ubuntu 26.04).

Now using a proper version check block with `#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)` to fix the build issue.
