### PR TITLE
frame: accept peer active_connection_id_limit above QUIC_CONN_ID_LIMIT

### DIFF
--- a/modules/net/quic/frame.c
+++ b/modules/net/quic/frame.c
@@ -3328,9 +3328,10 @@ int quic_frame_parse_transport_params_ext(struct sock *sk,
 		case QUIC_TRANSPORT_PARAM_ACTIVE_CONNECTION_ID_LIMIT:
 			if (!quic_get_param(&value, &p, &len))
 				return -EINVAL;
-			if (value < QUIC_CONN_ID_LEAST ||
-			    value > QUIC_CONN_ID_LIMIT)
+			if (value < QUIC_CONN_ID_LEAST)
 				return -EINVAL;
+			if (value > QUIC_CONN_ID_LIMIT)
+				value = QUIC_CONN_ID_LIMIT;
 			params->active_connection_id_limit = value;
 			break;
 		case QUIC_TRANSPORT_PARAM_MAX_DATAGRAM_FRAME_SIZE:


### PR DESCRIPTION
Disclaimer: this patch has been generate using claude code.

Fixes #77.

## Summary

`quic_frame_parse_transport_params_ext()` rejects a peer whose `active_connection_id_limit` transport parameter exceeds `QUIC_CONN_ID_LIMIT` (8), closing the connection with `TRANSPORT_PARAMETER_ERROR` during the handshake. RFC 9000 §18.2 only makes values **below 2** invalid — the parameter expresses the *sender's* willingness to store connection IDs, and imposes no obligation on the receiver, which may always issue fewer. This PR keeps the RFC-required lower-bound rejection and **clamps** the stored value to `QUIC_CONN_ID_LIMIT` instead of rejecting, since the stored copy only bounds how many connection IDs this endpoint issues.

## Why it matters

Apple's Network.framework QUIC stack (`NWProtocolQUIC`, macOS 12+/iOS 15+) advertises `active_connection_id_limit = 64` with no API to change it — so every Apple QUIC client is rejected at the transport-parameter stage. We hit this bringing up SMB-over-QUIC from macOS against Samba 4.23.6 on `quic.ko`: the server ACKs the client Initials, sends `CONNECTION_CLOSE(TRANSPORT_PARAMETER_ERROR)`, never a ServerHello, and Samba logs only `tstream_tls_quic_handshake: NT_STATUS_INTERNAL_ERROR` (EPIPE), which makes the cause invisible without a packet capture. OpenSSL's QUIC client (advertises 2) and Samba's own client connect fine, so same-stack testing doesn't catch it. Full evidence (decrypted-Initial TP dump, A/B discriminator, code trace) is in #77.

## Validation

Applied to the DKMS build on Ubuntu 26.04 (kernel 7.0): with the clamp, an Apple NWProtocolQUIC client completes the handshake and full SMB-over-QUIC sessions (NEGOTIATE, NTLM auth, share enumeration, multi-MB transfers with verified checksums, TLS trust matrix) run against Samba 4.23.6; without it, every attempt is closed with `TRANSPORT_PARAMETER_ERROR`. I could not build the module on macOS (expected); validation was on the Linux rig above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
